### PR TITLE
🎉 Servidor do Discord no comando !social

### DIFF
--- a/twitch/config/commands.json
+++ b/twitch/config/commands.json
@@ -137,7 +137,8 @@
         "/me 📺: https://www.youtube.com/moniquelive",
         "/me 🤝: https://stackoverflow.com/users/9793/cyber-oliveira",
         "/me 📖: https://dev.to/moniquelive",
-        "/me 💌: https://t.me/joinchat/nq7dy4jqN01kNmVh"
+        "/me 💌: https://t.me/joinchat/nq7dy4jqN01kNmVh",
+        "/me 📣: https://discord.gg/F6F8kE5ABQ"
       ]
     },
     {


### PR DESCRIPTION
- Corrige o  erro do comando `!social` que não exibia o servidor da comunidade no Discord
- 02Pat


Co-authored-by: leoggo <38364010+leoggo@users.noreply.github.com>